### PR TITLE
投稿詳細画面を作成

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import Image from "next/image";
+
+const page = () => {
+  return (
+    <div className=" h-screen p-4 flex flex-col items-center">
+      <Card className="shadow-xl rounded-xl mb-5 w-1/2 hover:cursor-pointer">
+        <CardHeader className="flex flex-col items-center justify-center">
+          <Image
+            src={"/no_image.webp"}
+            width={300}
+            height={200}
+            alt="投稿画像"
+            className="rounded-lg mb-3"
+            priority
+          />
+          <CardTitle>タイトル</CardTitle>
+          <div className="flex items-start w-full gap-1">
+            <Badge className="bg-deepRed">タグ1</Badge>
+            <Badge className="bg-deepRed">タグ2</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="pl-5">
+            <p>投稿内容</p>
+          </div>
+          <div className="p-5">
+            <p>ユーザー名</p>
+            <p>投稿日</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,8 +1,30 @@
+"use client";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
+import { useCallback, useEffect, useState } from "react";
+import { Post } from "@/app/types";
+import { useParams } from "next/navigation";
 
-const page = () => {
+const Page = () => {
+  const [post, setPost] = useState<Post | null>(null);
+  const { id } = useParams();
+
+  const getPost = useCallback(async () => {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/api/posts/${id}`
+    );
+    const data = await res.json();
+    setPost(data);
+  }, [id]);
+
+  useEffect(() => {
+    getPost();
+  }, [getPost]);
+
+  if (!post) return null;
+
   return (
     <div className=" h-screen p-4 flex flex-col items-center">
       <Card className="shadow-xl rounded-xl mb-5 w-1/2 hover:cursor-pointer">
@@ -15,7 +37,7 @@ const page = () => {
             className="rounded-lg mb-3"
             priority
           />
-          <CardTitle>タイトル</CardTitle>
+          <CardTitle>{post.title}</CardTitle>
           <div className="flex items-start w-full gap-1">
             <Badge className="bg-deepRed">タグ1</Badge>
             <Badge className="bg-deepRed">タグ2</Badge>
@@ -23,11 +45,11 @@ const page = () => {
         </CardHeader>
         <CardContent>
           <div className="pl-5">
-            <p>投稿内容</p>
+            <p>{post.content}</p>
           </div>
           <div className="p-5">
-            <p>ユーザー名</p>
-            <p>投稿日</p>
+            <p>{post.user.name}</p>
+            <p>投稿日 {new Date(post.created_at).toLocaleDateString()}</p>
           </div>
         </CardContent>
       </Card>
@@ -35,4 +57,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default Page;

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -2,6 +2,7 @@ import { Post } from "@/app/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Image from "next/image";
 import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
 
 const PostCard = ({ id, title, image, user, created_at }: Post) => {
   return (
@@ -17,9 +18,13 @@ const PostCard = ({ id, title, image, user, created_at }: Post) => {
             priority
           />
           <CardTitle className="text-center">{title}</CardTitle>
+          <div className="flex items-start w-full gap-1 pl-5">
+            <Badge className="bg-deepRed">タグ1</Badge>
+            <Badge className="bg-deepRed">タグ2</Badge>
+          </div>
         </CardHeader>
         <CardContent>
-          <div className="p-5">
+          <div className="pl-5">
             <p>{user.name}</p>
             <p>投稿日 {new Date(created_at).toLocaleDateString()}</p>
           </div>

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -1,28 +1,31 @@
 import { Post } from "@/app/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Image from "next/image";
+import Link from "next/link";
 
-const PostCard = ({ title, image, user, created_at }: Post) => {
+const PostCard = ({ id, title, image, user, created_at }: Post) => {
   return (
-    <Card className="shadow-xl rounded-xl mb-5 hover:cursor-pointer">
-      <CardHeader className="flex flex-col items-center justify-center">
-        <Image
-          src={image || "/no_image.webp"}
-          width={300}
-          height={200}
-          alt="投稿画像"
-          className="rounded-lg mb-3"
-          priority
-        />
-        <CardTitle className="text-center">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="p-5">
-          <p>{user.name}</p>
-          <p>投稿日 {new Date(created_at).toLocaleDateString()}</p>
-        </div>
-      </CardContent>
-    </Card>
+    <Link href={`/posts/${id}`}>
+      <Card className="shadow-xl rounded-xl mb-5 hover:cursor-pointer">
+        <CardHeader className="flex flex-col items-center justify-center">
+          <Image
+            src={image || "/no_image.webp"}
+            width={300}
+            height={200}
+            alt="投稿画像"
+            className="rounded-lg mb-3"
+            priority
+          />
+          <CardTitle className="text-center">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="p-5">
+            <p>{user.name}</p>
+            <p>投稿日 {new Date(created_at).toLocaleDateString()}</p>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   );
 };
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
### 概要
投稿詳細画面を作成。一応投稿一覧・詳細画面のカードにタグを追加しておいた。検索機能をどうするかは考え中だが、もしタグで検索できるようにした場合を考え今回追加しておいた。

### 該当Issue
#10 