### PR TITLE
タグを使った検索機能を実装

### DIFF
--- a/src/app/api/posts.ts
+++ b/src/app/api/posts.ts
@@ -1,4 +1,4 @@
-import { PostParams } from "../types";
+import { PostApiParams } from "../types";
 
 export const getAllPosts = async () => {
   const res = await fetch(
@@ -14,7 +14,7 @@ export const getPostById = async (id: string) => {
   return await res.json();
 };
 
-export const createPost = async (params: PostParams) => {
+export const createPost = async (params: PostApiParams) => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/api/posts`,
     {
@@ -29,7 +29,7 @@ export const createPost = async (params: PostParams) => {
   return await res.json();
 };
 
-export const updatePostById = async (id: string, params: PostParams) => {
+export const updatePostById = async (id: string, params: PostApiParams) => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/api/posts/${id}`,
     {

--- a/src/app/api/posts.ts
+++ b/src/app/api/posts.ts
@@ -1,4 +1,4 @@
-import { PostApiParams } from "../types";
+import { PostApiParams, SearchPostParams } from "../types";
 
 export const getAllPosts = async () => {
   const res = await fetch(
@@ -50,4 +50,12 @@ export const deletePostById = async (id: string) => {
     credentials: "include",
   });
   return;
+};
+
+export const searchPostsByTag = async (params: SearchPostParams) => {
+  const query = new URLSearchParams(params);
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/api/posts/tags?${query}`
+  );
+  return await res.json();
 };

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -18,18 +18,18 @@ const Page = () => {
   const router = useRouter();
   const { currentUser } = useAuthContext();
 
-  const getPost = useCallback(async () => {
+  const getPost = async () => {
     try {
       const res = await getPostById(id.toString());
       setPost(res);
     } catch (e) {
       console.error(e);
     }
-  }, [id]);
+  };
 
   useEffect(() => {
     getPost();
-  }, [getPost]);
+  }, [setPost]);
 
   const deletePost = async () => {
     const isConfirm = confirm("本当に削除しますか？");

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { deletePostById, getPostById } from "@/app/api/posts";
 import EditPostDialog from "@/components/posts/EditPostDialog";
 import { useAuthContext } from "@/app/context/AuthContext";
+import PostTag from "@/components/posts/PostTag";
 
 const Page = () => {
   const [post, setPost] = useState<Post | null>(null);
@@ -47,7 +48,7 @@ const Page = () => {
 
   return (
     <div className=" h-screen p-4 flex flex-col items-center">
-      <Card className="shadow-xl rounded-xl mb-5 w-1/2 hover:cursor-pointer">
+      <Card className="shadow-xl rounded-xl mb-5 w-1/2">
         <CardHeader className="flex flex-col items-center justify-center">
           <Image
             src={"/no_image.webp"}
@@ -59,8 +60,9 @@ const Page = () => {
           />
           <CardTitle>{title}</CardTitle>
           <div className="flex items-start w-full gap-1">
-            <Badge className="bg-deepRed hover:bg-rose-700">タグ1</Badge>
-            <Badge className="bg-deepRed hover:bg-rose-700">タグ2</Badge>
+            {post.tags.map((tag) => (
+              <PostTag key={tag.id} name={tag.name} />
+            ))}
           </div>
         </CardHeader>
         <CardContent>

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Post } from "@/app/types";
 import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -25,14 +25,18 @@ const Page = () => {
   return (
     <div className=" h-screen p-4">
       <h2 className="text-3xl m-4 text-center">投稿一覧</h2>
-
       <SearchPostField setPosts={setPosts} />
-
-      <div className="grid grid-cols-3 gap-4">
-        {posts.map((post) => (
-          <PostCard key={post.id} {...post} />
-        ))}
-      </div>
+      {posts.length === 0 ? (
+        <p className="flex items-center justify-center text-3xl min-h-32">
+          投稿がありません
+        </p>
+      ) : (
+        <div className="grid grid-cols-3 gap-4">
+          {posts.map((post) => (
+            <PostCard key={post.id} {...post} />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -4,6 +4,7 @@ import PostCard from "@/components/posts/PostCard";
 import { useEffect, useState } from "react";
 import { Post } from "../types";
 import { getAllPosts } from "../api/posts";
+import SearchPostField from "@/components/posts/SearchPostField";
 
 const Page = () => {
   const [posts, setPosts] = useState<Post[]>([]);
@@ -24,6 +25,9 @@ const Page = () => {
   return (
     <div className=" h-screen p-4">
       <h2 className="text-3xl m-4 text-center">投稿一覧</h2>
+
+      <SearchPostField setPosts={setPosts} />
+
       <div className="grid grid-cols-3 gap-4">
         {posts.map((post) => (
           <PostCard key={post.id} {...post} />

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -17,13 +17,12 @@ export type Post = {
   content: string;
   image?: string;
   created_at: string;
-  updated_at: string;
   user_id: number;
   user: {
+    name: string;
+  };
+  tags: {
     id: number;
     name: string;
-    email: string;
-    created_at: string;
-    updated_at: string;
-  };
+  }[];
 };

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -9,7 +9,14 @@ export type SignUpParams = z.infer<typeof signUpSchema>;
 
 export type LoginParams = z.infer<typeof loginSchema>;
 
-export type PostParams = z.infer<typeof postSchema>;
+export type PostFormParams = z.infer<typeof postSchema>;
+
+export type PostApiParams = {
+  title: string;
+  content: string;
+  image?: string;
+  tags?: string[];
+};
 
 export type Post = {
   id: number;

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   loginSchema,
   postSchema,
+  searchPostSchema,
   signUpSchema,
 } from "@/app/utils/validationSchema";
 
@@ -10,6 +11,8 @@ export type SignUpParams = z.infer<typeof signUpSchema>;
 export type LoginParams = z.infer<typeof loginSchema>;
 
 export type PostFormParams = z.infer<typeof postSchema>;
+
+export type SearchPostParams = z.infer<typeof searchPostSchema>;
 
 export type PostApiParams = {
   title: string;

--- a/src/app/utils/validationSchema.ts
+++ b/src/app/utils/validationSchema.ts
@@ -36,6 +36,13 @@ const image = z
   }, "画像は10MB以下のjpeg, png, webp形式で選択してください。")
   .transform((value) => (value instanceof FileList ? value[0] : value));
 
+const tags = z
+  .string()
+  .max(255, "タグ全体で255文字以下で入力してください。")
+  .refine((data) => data.split(/\s+/).filter(Boolean).length <= 3, {
+    message: "タグは最大3つまでです。",
+  });
+
 export const signUpSchema = z.object({
   name,
   email,
@@ -51,4 +58,5 @@ export const postSchema = z.object({
   title,
   content,
   image,
+  tags,
 });

--- a/src/app/utils/validationSchema.ts
+++ b/src/app/utils/validationSchema.ts
@@ -60,3 +60,7 @@ export const postSchema = z.object({
   image,
   tags,
 });
+
+export const searchPostSchema = z.object({
+  tag_name: z.string().max(255, "タグは255文字以下で入力してください。"),
+});

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -15,7 +15,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { loginSchema } from "../app/utils/validationSchema";
 import { LoginParams } from "../app/types";
-import { getCurrentUser, login } from "@/app/api/auth";
+import { login } from "@/app/api/auth";
 import { useAuthContext } from "@/app/context/AuthContext";
 
 const LoginForm = () => {
@@ -32,9 +32,8 @@ const LoginForm = () => {
 
   const onSubmit = async (params: LoginParams) => {
     try {
-      login(params);
-      const user = await getCurrentUser();
-      setCurrentUser(user);
+      const res = await login(params);
+      setCurrentUser(res.user);
       setIsSignedIn(true);
       router.push("/posts");
     } catch (e) {

--- a/src/components/posts/CreatePostForm.tsx
+++ b/src/components/posts/CreatePostForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { PostParams } from "@/app/types";
+import { PostApiParams, PostFormParams } from "@/app/types";
 import { postSchema } from "@/app/utils/validationSchema";
 import { Button } from "../ui/button";
 import { useRouter } from "next/navigation";
@@ -21,18 +21,24 @@ import { createPost } from "@/app/api/posts";
 const CreatePostForm = () => {
   const router = useRouter();
 
-  const form = useForm<PostParams>({
+  const form = useForm<PostFormParams>({
     resolver: zodResolver(postSchema),
     defaultValues: {
       title: "",
       content: "",
       image: "",
+      tags: "",
     },
   });
 
-  const onSubmit = async (params: PostParams) => {
+  const onSubmit = async (data: PostFormParams) => {
+    const tagsArray = data.tags.split(/\s+/).filter(Boolean);
+    const apiParams: PostApiParams = {
+      ...data,
+      tags: tagsArray,
+    };
     try {
-      await createPost(params);
+      await createPost(apiParams);
       router.push("/posts");
     } catch (e) {
       console.log(e);
@@ -64,6 +70,23 @@ const CreatePostForm = () => {
               <FormLabel>投稿内容</FormLabel>
               <FormControl>
                 <Textarea className="min-h-[160px]" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="tags"
+          render={({ field }) => (
+            <FormItem className="mb-2">
+              <FormLabel>タグ</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder="タグをスペース区切りで入力（最大3つ）"
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -2,9 +2,9 @@ import { Post } from "@/app/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Image from "next/image";
 import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
+import PostTag from "./PostTag";
 
-const PostCard = ({ id, title, image, user, created_at }: Post) => {
+const PostCard = ({ id, title, image, user, created_at, tags }: Post) => {
   const { name } = user;
   return (
     <Link href={`/posts/${id}`}>
@@ -20,8 +20,9 @@ const PostCard = ({ id, title, image, user, created_at }: Post) => {
           />
           <CardTitle className="text-center">{title}</CardTitle>
           <div className="flex items-start w-full gap-1 pl-5">
-            <Badge className="bg-deepRed hover:bg-rose-700">タグ1</Badge>
-            <Badge className="bg-deepRed hover:bg-rose-700">タグ2</Badge>
+            {tags.map((tag) => (
+              <PostTag key={tag.id} {...tag} />
+            ))}
           </div>
         </CardHeader>
         <CardContent>

--- a/src/components/posts/PostTag.tsx
+++ b/src/components/posts/PostTag.tsx
@@ -1,0 +1,11 @@
+import { Badge } from "@/components/ui/badge";
+
+type PostTagProps = {
+  name: string;
+};
+
+const PostTag = ({ name }: PostTagProps) => {
+  return <Badge className="bg-deepRed pointer-events-none">{name}</Badge>;
+};
+
+export default PostTag;

--- a/src/components/posts/SearchPostField.tsx
+++ b/src/components/posts/SearchPostField.tsx
@@ -1,0 +1,66 @@
+import { Post, SearchPostParams } from "@/app/types";
+import { searchPostSchema } from "@/app/utils/validationSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import { getAllPosts, searchPostsByTag } from "@/app/api/posts";
+
+type SearchPostFieldProps = {
+  setPosts: React.Dispatch<React.SetStateAction<Post[]>>;
+};
+
+const SearchPostField = ({ setPosts }: SearchPostFieldProps) => {
+  const form = useForm<SearchPostParams>({
+    resolver: zodResolver(searchPostSchema),
+    defaultValues: {
+      tag_name: "",
+    },
+  });
+
+  const onSubmit = async (params: SearchPostParams) => {
+    try {
+      if (params.tag_name === "") {
+        const res = await getAllPosts();
+        setPosts(res.data);
+      } else {
+        const res = await searchPostsByTag(params);
+        setPosts(res.data);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex items-center justify-center mx-auto mb-4 gap-2"
+      >
+        <FormField
+          control={form.control}
+          name="tag_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input {...field} placeholder="タグを入力してください" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">検索</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default SearchPostField;

--- a/src/components/posts/SearchPostField.tsx
+++ b/src/components/posts/SearchPostField.tsx
@@ -39,6 +39,12 @@ const SearchPostField = ({ setPosts }: SearchPostFieldProps) => {
     }
   };
 
+  const handleReset = async () => {
+    form.reset();
+    const res = await getAllPosts();
+    setPosts(res.data);
+  };
+
   return (
     <Form {...form}>
       <form
@@ -58,6 +64,9 @@ const SearchPostField = ({ setPosts }: SearchPostFieldProps) => {
           )}
         />
         <Button type="submit">検索</Button>
+        <Button type="reset" variant="destructive" onClick={handleReset}>
+          リセット
+        </Button>
       </form>
     </Form>
   );


### PR DESCRIPTION
### 概要
投稿一覧画面に検索フォームを用意し、タグの名前に部分一致する投稿を表示するように実装。検索に該当する投稿がなかった場合は「投稿がありません」と表示するようにし、検索欄が空白の状態で検索、もしくは「リセット」ボタンを押せば全投稿を対象に取得するようにしてある。
タグ検索機能の実装に伴い、投稿一覧・詳細には投稿に紐づいたタグを表示するように変更。また投稿作成・更新フォームにはタグの入力欄を追加し、タグを4つ以上入力するとバリデーションメッセージが表示される。

行ったバグ修正とリファクタリングを下に記述

1. ログイン関数実行時にawaitが抜けていたことによるバグを修正。
　login関数実行時にawaitが抜けていたため、ログイン直後だとログインしていない判定になっていたので修正。

2. ファイル内で使用していない関数・コンポーネントUIのimport文を削除
　これはただの消し忘れ。

### 該当Issue
#7 